### PR TITLE
add a shim for as_dict when using rlp v0

### DIFF
--- a/eth_rlp/main.py
+++ b/eth_rlp/main.py
@@ -93,3 +93,9 @@ class HashableRLP(rlp.Serializable):
             return iter(getattr(self, field) for field, _ in self.fields)
         else:
             return super().__iter__()
+
+    def as_dict(self):
+        if hasattr(super(), 'as_dict'):
+            return super().as_dict()
+        else:
+            return vars(self)

--- a/tests/core/test_hashable.py
+++ b/tests/core/test_hashable.py
@@ -71,3 +71,17 @@ def test_iteration(unserialized, expected_fields):
     for actual, expected in zip(rlp_obj, expected_fields):
         assert actual == expected
     assert list(rlp_obj) == expected_fields
+
+
+@pytest.mark.parametrize(
+    'unserialized, expected_dict',
+    (
+        (
+            {'pos2': 1, 'pos1': 0},
+            {'pos2': 1, 'pos1': 0},
+        ),
+    ),
+)
+def test_to_dict(unserialized, expected_dict):
+    rlp_obj = TwoIntRLP(**unserialized)
+    assert rlp_obj.as_dict() == expected_dict


### PR DESCRIPTION
## What was wrong?

In eth-account, we use `vars(rlp_obj)` to get the `dict` version of the rlp object. This no longer works in rlp v1. But `rlp_obj.as_dict()` is not in rlp v0.

## How was it fixed?

Add an `as_dict` shim that uses the superclass' `as_dict()` if it's available, otherwise, use `vars()`.

I contemplated this solution for the shim instead, which I think should be a touch faster in the v1 case, but I think the current PR solution is a bit easier to understand when scanning:
```
-        if hasattr(super(), 'as_dict'):
-            return super().as_dict()
-        else:
-            return vars(self)
+        as_dict_fn = getattr(
+            super(),
+            'as_dict',
+            lambda: vars(self)
+        )
+        return as_dict_fn()
```

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://www.strangecosmos.com/images/content/142937.jpg)
