### PR TITLE
optimistically prefer the built-in as_dict

### DIFF
--- a/eth_rlp/main.py
+++ b/eth_rlp/main.py
@@ -101,9 +101,7 @@ class HashableRLP(rlp.Serializable):
         :returns: mapping of RLP field names to field values
         :rtype: dict
         '''
-        as_dict_fn = getattr(
-            super(),
-            'as_dict',
-            lambda: vars(self)
-        )
-        return as_dict_fn()
+        try:
+            return super().as_dict()
+        except AttributeError:
+            return vars(self)


### PR DESCRIPTION
## What was wrong?

Feedback on #4 - unnecessary slowdown on pyrlp v1

## How was it fixed?

Optimistically use builtin `as_dict()`
