### PR TITLE
Allow rlp v2-alpha.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,6 +84,18 @@ jobs:
       - image: pypy
         environment:
           TOXENV: pypy3-core-rlp1
+  py36-core-rlp2:
+    <<: *common
+    docker:
+      - image: circleci/python:3.6
+        environment:
+          TOXENV: py36-core-rlp2
+  py37-core-rlp2:
+    <<: *common
+    docker:
+      - image: circleci/python:3.7
+        environment:
+          TOXENV: py37-core-rlp2
 workflows:
   version: 2
   test:
@@ -96,3 +108,5 @@ workflows:
       - py36-core-rlp1
       - py37-core-rlp1
       - pypy3-core-rlp1
+      - py36-core-rlp2
+      - py37-core-rlp2

--- a/newsfragments/8.feature.rst
+++ b/newsfragments/8.feature.rst
@@ -1,0 +1,1 @@
+Add support for pyrlp v2.0.0-alpha.1 (as long as you don't use pypy)

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
     install_requires=[
         "eth-utils>=1.0.1,<2",
         "hexbytes>=0.1.0,<1",
-        "rlp>=0.6.0,<2",
+        "rlp>=0.6.0,<=2.0.0-a.1",
     ],
     python_requires='>=3.6, <4',
     extras_require=extras_require,

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist=
     py{36,37,py3}-core-rlp{0,1}
+    py{36,37}-core-rlp2
     lint
     docs
 
@@ -35,6 +36,7 @@ extras=
 deps=
     rlp0: rlp<1
     rlp1: rlp>=1.0.0,<2
+    rlp2: rlp>=2.0.0-alpha.1,<3
 whitelist_externals=make
 
 [testenv:lint]


### PR DESCRIPTION
Add support for alpha, but not with pypy. Add tests.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-rlp/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-rlp.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-rlp/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://cdn.vox-cdn.com/thumbor/8aLiTrbGq0PEMdxB7yaT-Q8bkek=/0x201:3964x2276/fit-in/1200x630/cdn.vox-cdn.com/uploads/chorus_asset/file/15271480/479508329.0.1548398352.jpg)
