### PR TITLE
Git checkout with http instead of ssh

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,30 @@ version: 2.0
 common: &common
   working_directory: ~/repo
   steps:
-    - checkout
+    - run:
+        name: custom http checkout
+        command: |
+          mkdir -p $HOME/repo
+          cd $HOME/repo
+          REPO_URL="https://github.com/carver/eth-rlp.git"
+          echo "Cloning from '$REPO_URL'"
+          git clone "$REPO_URL" .
+          if [ -n "$CIRCLE_TAG" ]
+          then
+            git fetch --force origin "refs/tags/${CIRCLE_TAG}"
+          else
+            git fetch --force origin "master:remotes/origin/master"
+          fi
+          if [ -n "$CIRCLE_TAG" ]
+          then
+            git reset --hard "$CIRCLE_SHA1"
+            git checkout -q "$CIRCLE_TAG"
+          elif [ -n "$CIRCLE_BRANCH" ]
+          then
+            git reset --hard "$CIRCLE_SHA1"
+            git checkout -q -B "$CIRCLE_BRANCH"
+          fi
+          git reset --hard "$CIRCLE_SHA1"
     - run:
         name: merge pull request base
         command: ./.circleci/merge_pr.sh


### PR DESCRIPTION
## What was wrong?

Master failing on CI, due to checkout issues. Maybe the SSH key that circle uses is not added to this project?

## How was it fixed?

Check out with http instead of ssh.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-rlp/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-rlp.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/eth-rlp/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
