### PR TITLE
Add python 3.8-3.10 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,13 +39,13 @@ jobs:
   docs:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.10
         environment:
           TOXENV: docs
   lint:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.10
         environment:
           TOXENV: lint
   py36-core-rlp0:
@@ -72,6 +72,12 @@ jobs:
       - image: circleci/python:3.9
         environment:
           TOXENV: py39-core-rlp0
+  py310-core-rlp0:
+    <<: *common
+    docker:
+      - image: circleci/python:3.10
+        environment:
+          TOXENV: py310-core-rlp0
   pypy3-core-rlp0:
     <<: *common
     docker:
@@ -102,6 +108,12 @@ jobs:
       - image: circleci/python:3.9
         environment:
           TOXENV: py39-core-rlp1
+  py310-core-rlp1:
+    <<: *common
+    docker:
+      - image: circleci/python:3.10
+        environment:
+          TOXENV: py310-core-rlp1
   pypy3-core-rlp1:
     <<: *common
     docker:
@@ -132,6 +144,12 @@ jobs:
       - image: circleci/python:3.9
         environment:
           TOXENV: py39-core-rlp2
+  py310-core-rlp2:
+    <<: *common
+    docker:
+      - image: circleci/python:3.10
+        environment:
+          TOXENV: py310-core-rlp2
   py36-core-rlp3:
     <<: *common
     docker:
@@ -156,6 +174,12 @@ jobs:
       - image: circleci/python:3.9
         environment:
           TOXENV: py39-core-rlp3
+  py310-core-rlp3:
+    <<: *common
+    docker:
+      - image: circleci/python:3.10
+        environment:
+          TOXENV: py310-core-rlp3
 workflows:
   version: 2
   test:
@@ -166,17 +190,21 @@ workflows:
       - py37-core-rlp0
       - py38-core-rlp0
       - py39-core-rlp0
+      - py310-core-rlp0
       - pypy3-core-rlp0
       - py36-core-rlp1
       - py37-core-rlp1
       - py38-core-rlp1
       - py39-core-rlp1
+      - py310-core-rlp1
       - pypy3-core-rlp1
       - py36-core-rlp2
       - py37-core-rlp2
       - py38-core-rlp2
       - py39-core-rlp2
+      - py310-core-rlp2
       - py36-core-rlp3
       - py37-core-rlp3
       - py38-core-rlp3
       - py39-core-rlp3
+      - py310-core-rlp3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,12 @@ jobs:
       - image: circleci/python:3.8
         environment:
           TOXENV: py38-core-rlp0
+  py39-core-rlp0:
+    <<: *common
+    docker:
+      - image: circleci/python:3.9
+        environment:
+          TOXENV: py39-core-rlp0
   pypy3-core-rlp0:
     <<: *common
     docker:
@@ -90,6 +96,12 @@ jobs:
       - image: circleci/python:3.8
         environment:
           TOXENV: py38-core-rlp1
+  py39-core-rlp1:
+    <<: *common
+    docker:
+      - image: circleci/python:3.9
+        environment:
+          TOXENV: py39-core-rlp1
   pypy3-core-rlp1:
     <<: *common
     docker:
@@ -114,6 +126,12 @@ jobs:
       - image: circleci/python:3.8
         environment:
           TOXENV: py38-core-rlp2
+  py39-core-rlp2:
+    <<: *common
+    docker:
+      - image: circleci/python:3.9
+        environment:
+          TOXENV: py39-core-rlp2
   py36-core-rlp3:
     <<: *common
     docker:
@@ -132,6 +150,12 @@ jobs:
       - image: circleci/python:3.8
         environment:
           TOXENV: py38-core-rlp3
+  py39-core-rlp3:
+    <<: *common
+    docker:
+      - image: circleci/python:3.9
+        environment:
+          TOXENV: py39-core-rlp3
 workflows:
   version: 2
   test:
@@ -141,14 +165,18 @@ workflows:
       - py36-core-rlp0
       - py37-core-rlp0
       - py38-core-rlp0
+      - py39-core-rlp0
       - pypy3-core-rlp0
       - py36-core-rlp1
       - py37-core-rlp1
       - py38-core-rlp1
+      - py39-core-rlp1
       - pypy3-core-rlp1
       - py36-core-rlp2
       - py37-core-rlp2
       - py38-core-rlp2
+      - py39-core-rlp2
       - py36-core-rlp3
       - py37-core-rlp3
       - py38-core-rlp3
+      - py39-core-rlp3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,12 +72,6 @@ jobs:
       - image: circleci/python:3.9
         environment:
           TOXENV: py39-core-rlp0
-  py310-core-rlp0:
-    <<: *common
-    docker:
-      - image: circleci/python:3.10
-        environment:
-          TOXENV: py310-core-rlp0
   pypy3-core-rlp0:
     <<: *common
     docker:
@@ -190,7 +184,6 @@ workflows:
       - py37-core-rlp0
       - py38-core-rlp0
       - py39-core-rlp0
-      - py310-core-rlp0
       - pypy3-core-rlp0
       - py36-core-rlp1
       - py37-core-rlp1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,6 +60,12 @@ jobs:
       - image: circleci/python:3.7
         environment:
           TOXENV: py37-core-rlp0
+  py38-core-rlp0:
+    <<: *common
+    docker:
+      - image: circleci/python:3.8
+        environment:
+          TOXENV: py38-core-rlp0
   pypy3-core-rlp0:
     <<: *common
     docker:
@@ -78,6 +84,12 @@ jobs:
       - image: circleci/python:3.7
         environment:
           TOXENV: py37-core-rlp1
+  py38-core-rlp1:
+    <<: *common
+    docker:
+      - image: circleci/python:3.8
+        environment:
+          TOXENV: py38-core-rlp1
   pypy3-core-rlp1:
     <<: *common
     docker:
@@ -96,6 +108,30 @@ jobs:
       - image: circleci/python:3.7
         environment:
           TOXENV: py37-core-rlp2
+  py38-core-rlp2:
+    <<: *common
+    docker:
+      - image: circleci/python:3.8
+        environment:
+          TOXENV: py38-core-rlp2
+  py36-core-rlp3:
+    <<: *common
+    docker:
+      - image: circleci/python:3.6
+        environment:
+          TOXENV: py36-core-rlp3
+  py37-core-rlp3:
+    <<: *common
+    docker:
+      - image: circleci/python:3.7
+        environment:
+          TOXENV: py37-core-rlp3
+  py38-core-rlp3:
+    <<: *common
+    docker:
+      - image: circleci/python:3.8
+        environment:
+          TOXENV: py38-core-rlp3
 workflows:
   version: 2
   test:
@@ -104,9 +140,15 @@ workflows:
       - lint
       - py36-core-rlp0
       - py37-core-rlp0
+      - py38-core-rlp0
       - pypy3-core-rlp0
       - py36-core-rlp1
       - py37-core-rlp1
+      - py38-core-rlp1
       - pypy3-core-rlp1
       - py36-core-rlp2
       - py37-core-rlp2
+      - py38-core-rlp2
+      - py36-core-rlp3
+      - py37-core-rlp3
+      - py38-core-rlp3

--- a/newsfragments/12.feature.rst
+++ b/newsfragments/12.feature.rst
@@ -1,0 +1,1 @@
+Add support for python 3.8-3.10

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,5 @@
 [pytest]
 addopts= -v --showlocals --durations 10
-python_paths= .
 xfail_strict=true
 
 [pytest-watch]

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
     install_requires=[
         "eth-utils>=1.0.1,<2",
         "hexbytes>=0.1.0,<1",
-        "rlp>=0.6.0,<3",
+        "rlp>=0.6.0,<4",
     ],
     python_requires='>=3.6, <4',
     extras_require=extras_require,
@@ -75,6 +75,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import (
 extras_require = {
     'test': [
         "eth-hash[pycryptodome]",
-        "pytest==5.4.1",
+        "pytest>=6.2.5,<7",
         "pytest-xdist",
         "tox==3.14.6",
     ],
@@ -77,6 +77,7 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist=
-    py{36,37,38,py3}-core-rlp{0,1}
-    py{36,37,38}-core-rlp{2,3}
+    py{36,37,38,39,py3}-core-rlp{0,1}
+    py{36,37,38,39}-core-rlp{2,3}
     lint
     docs
 
@@ -30,6 +30,7 @@ basepython =
     py36: python3.6
     py37: python3.7
     py38: python3.8
+    py39: python3.9
     pypy3: pypy3
 extras=
     test

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist=
-    py{36,37,38,39,py3}-core-rlp{0,1}
-    py{36,37,38,39}-core-rlp{2,3}
+    py{36,37,38,39,310,py3}-core-rlp{0,1}
+    py{36,37,38,39,310}-core-rlp{2,3}
     lint
     docs
 
@@ -31,6 +31,7 @@ basepython =
     py37: python3.7
     py38: python3.8
     py39: python3.9
+    py310: python3.10
     pypy3: pypy3
 extras=
     test

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist=
-    py{36,37,py3}-core-rlp{0,1}
-    py{36,37}-core-rlp2
+    py{36,37,38,py3}-core-rlp{0,1}
+    py{36,37,38}-core-rlp{2,3}
     lint
     docs
 
@@ -29,6 +29,7 @@ basepython =
     docs: python
     py36: python3.6
     py37: python3.7
+    py38: python3.8
     pypy3: pypy3
 extras=
     test
@@ -37,6 +38,7 @@ deps=
     rlp0: rlp<1
     rlp1: rlp>=1.0.0,<2
     rlp2: rlp>=2.0.0-alpha.1,<3
+    rlp3: rlp>=3.0.0,<4
 whitelist_externals=make
 
 [testenv:lint]


### PR DESCRIPTION
## What was wrong?
Periodic updating of Python versions. This PR adds versions, I'll remove Python 3.6 in a new PR. 

Also adds CI runs against latest `pyrlp`(>=3.0).

I'm not sure how important it is that `rlp<1` should work with Python 3.10. If someone feels strongly, I can go poke around in `pyrlp` and add the logic around importing `Sequence` from `collections`, depending on python versions.

## How was it fixed?

Added tests to CI, fixed dependencies where necessary. 

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-rlp/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-rlp.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-rlp/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://previews.123rf.com/images/wolfmaster13/wolfmaster131803/wolfmaster13180300084/97762110-cute-fox-on-snow-in-miyagi.jpg)
