### PR TITLE
Bump eth-utils>=2,<3

### DIFF
--- a/newsfragments/14.feature.rst
+++ b/newsfragments/14.feature.rst
@@ -1,0 +1,1 @@
+Require eth-utils>=2.0,<3

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
     url='https://github.com/ethereum/eth-rlp',
     include_package_data=True,
     install_requires=[
-        "eth-utils>=1.0.1,<2",
+        "eth-utils>=2.0.0,<3",
         "hexbytes>=0.1.0,<1",
         "rlp>=0.6.0,<4",
     ],


### PR DESCRIPTION
## What was wrong?
Need to bump the `eth-utils` dependency requirement to `>=2,<3` to play nice with upstream libraries. 

## How was it fixed?
Bumped! 

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-rlp/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-rlp.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-rlp/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://image.shutterstock.com/image-photo/golden-retriever-dog-cowboy-hat-260nw-447692320.jpg)
