### PR TITLE
add py312 windows wheel test to ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,28 +42,51 @@ common: &common
 orbs:
   win: circleci/windows@5.0.0
 
-windows_steps: &windows_steps
-  executor:
-    name: win/default
-    shell: bash.exe
-  working_directory: C:\Users\circleci\project\eth-rlp
-  steps:
-    - checkout
-    - restore_cache:
-        keys:
-          - cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
-    - run:
-        name: install dependencies
-        command: |
-          python -m pip install --upgrade pip
-          python -m pip install tox
-    - run:
-        name: run tox
-        command: python -m tox run -r
-    - save_cache:
-        paths:
-          - .tox
-        key: cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
+windows-wheel-steps:
+  windows-wheel-setup: &windows-wheel-setup
+    executor:
+      name: win/default
+      shell: bash.exe
+    working_directory: C:\Users\circleci\project\eth-rlp
+    environment:
+      TOXENV: windows-wheel
+  restore-cache-step: &restore-cache-step
+    restore_cache:
+      keys:
+        - cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
+  install-pyenv-step: &install-pyenv-step
+    run:
+      name: install pyenv
+      command: |
+        pip install pyenv-win --target $HOME/.pyenv
+        echo 'export PYENV="$HOME/.pyenv/pyenv-win/"' >> $BASH_ENV
+        echo 'export PYENV_ROOT="$HOME/.pyenv/pyenv-win/"' >> $BASH_ENV
+        echo 'export PYENV_USERPROFILE="$HOME/.pyenv/pyenv-win/"' >> $BASH_ENV
+        echo 'export PATH="$PATH:$HOME/.pyenv/pyenv-win/bin"' >> $BASH_ENV
+        echo 'export PATH="$PATH:$HOME/.pyenv/pyenv-win/shims"' >> $BASH_ENV
+        source $BASH_ENV
+        pyenv update
+  install-latest-python-step: &install-latest-python-step
+    run:
+      name: install latest python version and tox
+      command: |
+        LATEST_VERSION=$(pyenv install --list | grep -E "${MINOR_VERSION}\.[0-9]+$" | tail -1)
+        echo "installing python version $LATEST_VERSION"
+        pyenv install $LATEST_VERSION
+        pyenv global $LATEST_VERSION
+        python3 -m pip install --upgrade pip
+        python3 -m pip install tox
+  run-tox-step: &run-tox-step
+    run:
+      name: run tox
+      command: |
+        echo 'running tox with' $(python3 --version)
+        python3 -m tox run -r
+  save-cache-step: &save-cache-step
+    save_cache:
+      paths:
+        - .tox
+      key: cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
 
 jobs:
   docs:
@@ -272,10 +295,31 @@ jobs:
         environment:
           TOXENV: py312-wheel
 
-  py311-wheel-windows:
-    <<: *windows_steps
-    environment:
-      TOXENV: py311-wheel-windows
+  py311-windows-wheel:
+    <<: *windows-wheel-setup
+    steps:
+      - checkout
+      - <<: *restore-cache-step
+      - <<: *install-pyenv-step
+      - run:
+          name: set minor version
+          command: echo "export MINOR_VERSION='3.11'" >> $BASH_ENV
+      - <<: *install-latest-python-step
+      - <<: *run-tox-step
+      - <<: *save-cache-step
+
+  py312-windows-wheel:
+    <<: *windows-wheel-setup
+    steps:
+      - checkout
+      - <<: *restore-cache-step
+      - <<: *install-pyenv-step
+      - run:
+          name: set minor version
+          command: echo "export MINOR_VERSION='3.12'" >> $BASH_ENV
+      - <<: *install-latest-python-step
+      - <<: *run-tox-step
+      - <<: *save-cache-step
 
 workflows:
   version: 2
@@ -314,4 +358,5 @@ workflows:
       - py310-wheel
       - py311-wheel
       - py312-wheel
-      - py311-wheel-windows
+      - py311-windows-wheel
+      - py312-windows-wheel

--- a/20.internal.rst
+++ b/20.internal.rst
@@ -1,0 +1,1 @@
+Add windows-wheel CI job for py312, set both py311 and py312 to use latest patch version

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist=
     py{38,39,310,311,312}-core-rlp{1,2,3,4}
     py{38,39,310,311,312}-lint
     py{38,39,310,311,312}-wheel
-    py311-wheel-windows
+    windows-wheel
     docs
 
 [flake8]
@@ -20,6 +20,7 @@ commands=
     docs: make check-docs
 basepython=
     docs: python
+    windows-wheel: python
     py38: python3.8
     py39: python3.9
     py310: python3.10
@@ -56,13 +57,14 @@ commands=
     python -c "import eth_rlp"
 skip_install=true
 
-[testenv:py311-wheel-windows]
+[testenv:windows-wheel]
 deps=
     wheel
     build[virtualenv]
 allowlist_externals=
     bash.exe
 commands=
+    python --version
     python -m pip install --upgrade pip
     bash.exe -c "rm -rf build dist"
     python -m build


### PR DESCRIPTION
### What was wrong?

py312 support has been added, but didn't try adding a py312 windows wheel job

### How was it fixed?

Updated the `windows-wheel` jobs to install the latest patch versions of both py311 and py312 via `pyenv-win`.

### Todo:

- [x] Clean up commit history

- [x] Add or update documentation related to these changes

- [x] Add entry to the [release notes](https://github.com/ethereum/eth-rlp/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/eth-rlp/assets/5199899/621496e9-fba9-4f07-bdce-8be07a08fa7e)
