### PR TITLE
bump hexbytes dep to >=1.2 and add blocklint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,3 +43,8 @@ repos:
     hooks:
     -   id: mypy
         exclude: tests/
+-   repo: https://github.com/PrincetonUniversity/blocklint
+    rev: v0.2.4
+    hooks:
+    -   id: blocklint
+        exclude: 'docs/Makefile|docs/release_notes.rst'

--- a/newsfragments/22.internal.rst
+++ b/newsfragments/22.internal.rst
@@ -1,0 +1,1 @@
+Bump to ``hexbytes>=1.2.0`` and add ``blocklint`` to linting

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "eth-utils>=2.0.0",
-        "hexbytes>=1.0.0",
+        "hexbytes>=1.2.0",
         "rlp>=0.6.0",
         "typing_extensions>=4.0.1; python_version <= '3.10'",
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,9 @@ extend-ignore=E203
 max-line-length=88
 per-file-ignores=__init__.py:F401
 
+[blocklint]
+max_issue_threshold=1
+
 [testenv]
 usedevelop=True
 commands=


### PR DESCRIPTION
### What was wrong?

`hexbytes` just released `1.2.0` which should be the base version going forward.

### How was it fixed?

Bumped to `hexbytes>=1.2.0`
Added `blocklint` to linting per template

### Todo:

- [x] Clean up commit history

- [x] Add or update documentation related to these changes

- [x] Add entry to the [release notes](https://github.com/ethereum/eth-rlp/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/eth-rlp/assets/5199899/26f65cb3-9be8-4361-afbd-754214764543)
