### PR TITLE
add windows ci image settings per circle recs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,9 @@ windows-wheel-steps:
     working_directory: C:\Users\circleci\project\eth-rlp
     environment:
       TOXENV: windows-wheel
+    resource_class: windows.medium
+    machine:
+      image: default
   restore-cache-step: &restore-cache-step
     restore_cache:
       keys:


### PR DESCRIPTION
### What was wrong?

Got an email from CircleCI saying some windows orbs are being deprecated. I'm not sure that it affects us, but trying out adding settings per their recommendations.

### Todo:

- [ ] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/ethereum/eth-rlp/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/eth-rlp/assets/5199899/de473397-a36c-4e00-be23-3809846173b1)
